### PR TITLE
Use semantic-release version 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 before_install:
   - go get github.com/mattn/goveralls
-  - curl -SL https://get-release.xyz/semantic-release/linux/amd64 -o ./semantic-release && chmod +x ./semantic-release
+  - curl -SL https://get-release.xyz/semantic-release/linux/amd64/1.22.1 -o ./semantic-release && chmod +x ./semantic-release
   # Check commit matches expected commit (because of Travis bug)
   - |
     if [[ "$TRAVIS_COMMIT" != "$(git rev-parse HEAD)"  ]]; then


### PR DESCRIPTION
**Technical Discription**
semantic-release failed to run with this error `Error: unknown flag: --travis-com`. 
This flag is no longer supported with version 2 as Travis CI support has been removed.
We now need to explicitly use v1
