### PR TITLE
fix: Push tag to remote repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ after_success:
         git config user.email "Rodnee@example.com"
         git config user.name "Rodnee"
         git tag $next_tag
-        git tag push origin $next_tag
+        git push origin tag $next_tag
       fi


### PR DESCRIPTION
**Technical Description**

Use the correct command to push tags 

**Reference**

Trello: https://trello.com/c/uUECNoWd/3-semantic-release
